### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/golf-mcp/golf/security/code-scanning/25](https://github.com/golf-mcp/golf/security/code-scanning/25)

To fix the problem, add a `permissions` block to the `lint` job in `.github/workflows/test.yml` to explicitly set the minimal required permissions. Since the `lint` job only needs to read repository contents (for checking out code and running static analysis), set `contents: read`. This change should be made directly under the `lint:` job definition (after `runs-on: ubuntu-latest`). No other changes are required, and this will not affect the existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
