### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/golf-mcp/golf/security/code-scanning/24](https://github.com/golf-mcp/golf/security/code-scanning/24)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the jobs. The safest approach is to add the block at the top level (applies to all jobs), unless a job requires additional permissions. For this workflow, the `test` and `lint` jobs only need to read repository contents, except that the `test` job uploads coverage to Codecov, which only requires `contents: read` (since it uploads to an external service, not to GitHub). Therefore, set `permissions: contents: read` at the workflow root, just below the `name` field and before `on:`.

**What to change:**  
- In `.github/workflows/test.yml`, add the following block after the `name: Tests` line:
  ```yaml
  permissions:
    contents: read
  ```
- No other changes are needed, as no job requires additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
