### PR TITLE
Add dynamic redirect URI validation for OAuth proxy

### DIFF
--- a/src/golf/auth/factory.py
+++ b/src/golf/auth/factory.py
@@ -452,6 +452,21 @@ def _create_oauth_proxy_provider(config: OAuthProxyConfig) -> "AuthProvider":
             "Please install it with: pip install golf-mcp-enterprise"
         ) from None
 
+    # Resolve static redirect patterns from environment variables
+    allowed_redirect_patterns = config.allowed_redirect_patterns
+    if config.allowed_redirect_patterns_env_var:
+        env_value = os.environ.get(config.allowed_redirect_patterns_env_var)
+        if env_value:
+            # Split comma-separated values and strip whitespace
+            allowed_redirect_patterns = [p.strip() for p in env_value.split(",") if p.strip()]
+
+    allowed_redirect_schemes = config.allowed_redirect_schemes
+    if config.allowed_redirect_schemes_env_var:
+        env_value = os.environ.get(config.allowed_redirect_schemes_env_var)
+        if env_value:
+            # Split comma-separated values and strip whitespace
+            allowed_redirect_schemes = [s.strip() for s in env_value.split(",") if s.strip()]
+
     # Create a new config with resolved values for the enterprise package
     resolved_config = OAuthProxyConfig(
         authorization_endpoint=authorization_endpoint,
@@ -463,6 +478,13 @@ def _create_oauth_proxy_provider(config: OAuthProxyConfig) -> "AuthProvider":
         redirect_path=config.redirect_path,
         scopes_supported=config.scopes_supported,
         token_verifier_config=config.token_verifier_config,
+        # Static redirect URI configuration (resolved from env vars)
+        allowed_redirect_patterns=allowed_redirect_patterns,
+        allowed_redirect_schemes=allowed_redirect_schemes,
+        # Dynamic redirect URI configuration (pass through callables)
+        allowed_redirect_patterns_func=config.allowed_redirect_patterns_func,
+        allowed_redirect_schemes_func=config.allowed_redirect_schemes_func,
+        redirect_uri_validator=config.redirect_uri_validator,
     )
 
     return create_oauth_proxy_provider(resolved_config)

--- a/src/golf/core/builder.py
+++ b/src/golf/core/builder.py
@@ -861,6 +861,16 @@ class CodeGenerator:
             transport=self.settings.transport,
         )
 
+        # Copy auth.py to dist if it contains callable fields (dynamic config)
+        if auth_components.get("copy_auth_file"):
+            auth_src = self.project_path / "auth.py"
+            auth_dst = self.output_dir / "auth.py"
+            if auth_src.exists():
+                shutil.copy(auth_src, auth_dst)
+                console.print("[dim]Copied auth.py for runtime configuration[/dim]")
+            else:
+                console.print("[yellow]Warning: auth.py not found but copy_auth_file was requested[/yellow]")
+
         # Create imports section
         imports = [
             "from fastmcp import FastMCP",

--- a/tests/auth/test_providers.py
+++ b/tests/auth/test_providers.py
@@ -5,8 +5,13 @@ import pytest
 from unittest.mock import Mock, patch
 from pydantic import ValidationError
 
-from golf.auth.providers import JWTAuthConfig, OAuthServerConfig, RemoteAuthConfig
-from golf.auth.factory import _create_jwt_provider, _create_oauth_server_provider, _create_remote_provider
+from golf.auth.providers import JWTAuthConfig, OAuthServerConfig, RemoteAuthConfig, OAuthProxyConfig, StaticTokenConfig
+from golf.auth.factory import (
+    _create_jwt_provider,
+    _create_oauth_server_provider,
+    _create_remote_provider,
+    _create_oauth_proxy_provider,
+)
 
 
 class TestJWTProviderCreation:
@@ -389,3 +394,224 @@ class TestOAuthServerCreation:
             # Verify OAuthProvider was called with None revocation options
             call_args = mock_oauth_provider.call_args[1]
             assert call_args["revocation_options"] is None
+
+
+class TestOAuthProxyDynamicRedirectUris:
+    """Test OAuth proxy configuration with dynamic redirect URI validation."""
+
+    def _create_base_config(self, **kwargs) -> OAuthProxyConfig:
+        """Create a base OAuth proxy config with required fields for testing."""
+        token_verifier = StaticTokenConfig(tokens={"test-token": {"client_id": "test", "scopes": ["read"]}})
+        defaults = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "client_id": "test-client",
+            "client_secret": "test-secret",
+            "base_url": "https://proxy.example.com",
+            "token_verifier_config": token_verifier,
+        }
+        defaults.update(kwargs)
+        return OAuthProxyConfig(**defaults)
+
+    def test_config_with_static_redirect_patterns(self) -> None:
+        """Test config creation with static redirect patterns list."""
+        config = self._create_base_config(
+            allowed_redirect_patterns=["https://app1.example.com/*", "https://app2.example.com/*"],
+            allowed_redirect_schemes=["myapp", "custom"],
+        )
+
+        assert config.allowed_redirect_patterns == ["https://app1.example.com/*", "https://app2.example.com/*"]
+        assert config.allowed_redirect_schemes == ["myapp", "custom"]
+        assert config.allowed_redirect_patterns_func is None
+        assert config.allowed_redirect_schemes_func is None
+        assert config.redirect_uri_validator is None
+
+    def test_config_with_callable_patterns_func(self) -> None:
+        """Test config creation with callable that returns patterns dynamically."""
+        call_count = 0
+
+        def get_patterns() -> list[str]:
+            nonlocal call_count
+            call_count += 1
+            # Simulate feature flag check
+            return ["https://dynamic-app.example.com/*"]
+
+        config = self._create_base_config(
+            allowed_redirect_patterns_func=get_patterns,
+        )
+
+        assert config.allowed_redirect_patterns_func is not None
+        assert callable(config.allowed_redirect_patterns_func)
+
+        # Call the function to verify it works
+        patterns = config.allowed_redirect_patterns_func()
+        assert patterns == ["https://dynamic-app.example.com/*"]
+        assert call_count == 1
+
+        # Call again to verify it can be called multiple times
+        patterns = config.allowed_redirect_patterns_func()
+        assert call_count == 2
+
+    def test_config_with_callable_schemes_func(self) -> None:
+        """Test config creation with callable that returns schemes dynamically."""
+
+        def get_schemes() -> list[str]:
+            # Could check feature flags, database, etc.
+            return ["myapp", "vscode"]
+
+        config = self._create_base_config(
+            allowed_redirect_schemes_func=get_schemes,
+        )
+
+        assert config.allowed_redirect_schemes_func is not None
+        schemes = config.allowed_redirect_schemes_func()
+        assert schemes == ["myapp", "vscode"]
+
+    def test_config_with_redirect_uri_validator(self) -> None:
+        """Test config creation with custom redirect URI validator function."""
+        allowed_uris = {"https://allowed.example.com/callback", "https://also-allowed.example.com/oauth"}
+
+        def validate_uri(uri: str) -> bool:
+            return uri in allowed_uris
+
+        config = self._create_base_config(
+            redirect_uri_validator=validate_uri,
+        )
+
+        assert config.redirect_uri_validator is not None
+        assert config.redirect_uri_validator("https://allowed.example.com/callback") is True
+        assert config.redirect_uri_validator("https://not-allowed.example.com/callback") is False
+
+    def test_config_with_mixed_static_and_dynamic(self) -> None:
+        """Test config with both static patterns and dynamic validator."""
+
+        def dynamic_validator(uri: str) -> bool:
+            return uri.startswith("https://dynamic")
+
+        config = self._create_base_config(
+            allowed_redirect_patterns=["https://static.example.com/*"],
+            allowed_redirect_patterns_func=lambda: ["https://func.example.com/*"],
+            redirect_uri_validator=dynamic_validator,
+        )
+
+        # All configurations should be set
+        assert config.allowed_redirect_patterns == ["https://static.example.com/*"]
+        assert config.allowed_redirect_patterns_func is not None
+        assert config.redirect_uri_validator is not None
+
+    def test_factory_passes_callable_to_enterprise(self) -> None:
+        """Test that factory function passes callable parameters to enterprise package."""
+        patterns_func = lambda: ["https://dynamic.example.com/*"]  # noqa: E731
+        schemes_func = lambda: ["myscheme"]  # noqa: E731
+        validator = lambda uri: uri.startswith("https://")  # noqa: E731
+
+        config = self._create_base_config(
+            allowed_redirect_patterns=["https://static.example.com/*"],
+            allowed_redirect_schemes=["http", "https"],
+            allowed_redirect_patterns_func=patterns_func,
+            allowed_redirect_schemes_func=schemes_func,
+            redirect_uri_validator=validator,
+        )
+
+        # Mock the golf_enterprise module import
+        mock_enterprise = Mock()
+        mock_provider_instance = Mock()
+        mock_enterprise.create_oauth_proxy_provider.return_value = mock_provider_instance
+
+        import sys
+
+        with patch.dict(sys.modules, {"golf_enterprise": mock_enterprise}):
+            provider = _create_oauth_proxy_provider(config)
+
+            # Verify the enterprise function was called
+            mock_enterprise.create_oauth_proxy_provider.assert_called_once()
+
+            # Get the resolved config passed to the enterprise function
+            resolved_config = mock_enterprise.create_oauth_proxy_provider.call_args[0][0]
+
+            # Verify static patterns are passed
+            assert resolved_config.allowed_redirect_patterns == ["https://static.example.com/*"]
+            assert resolved_config.allowed_redirect_schemes == ["http", "https"]
+
+            # Verify callable functions are passed through
+            assert resolved_config.allowed_redirect_patterns_func is patterns_func
+            assert resolved_config.allowed_redirect_schemes_func is schemes_func
+            assert resolved_config.redirect_uri_validator is validator
+
+            assert provider == mock_provider_instance
+
+    def test_factory_resolves_patterns_from_env_var(self) -> None:
+        """Test that factory resolves static patterns from environment variable."""
+        config = self._create_base_config(
+            allowed_redirect_patterns_env_var="REDIRECT_PATTERNS",
+            allowed_redirect_schemes_env_var="REDIRECT_SCHEMES",
+        )
+
+        env_vars = {
+            "REDIRECT_PATTERNS": "https://env1.example.com/*, https://env2.example.com/*",
+            "REDIRECT_SCHEMES": "myapp, custom",
+        }
+
+        # Mock the golf_enterprise module import
+        mock_enterprise = Mock()
+        mock_enterprise.create_oauth_proxy_provider.return_value = Mock()
+
+        import sys
+
+        with patch.dict(os.environ, env_vars), patch.dict(sys.modules, {"golf_enterprise": mock_enterprise}):
+            _create_oauth_proxy_provider(config)
+
+            resolved_config = mock_enterprise.create_oauth_proxy_provider.call_args[0][0]
+            assert resolved_config.allowed_redirect_patterns == [
+                "https://env1.example.com/*",
+                "https://env2.example.com/*",
+            ]
+            assert resolved_config.allowed_redirect_schemes == ["myapp", "custom"]
+
+    def test_callable_integration_with_feature_flags(self) -> None:
+        """Test realistic integration pattern with simulated feature flags."""
+        # Simulate a feature flag service
+        feature_flags = {"enable_new_redirect_uris": False}
+
+        def get_allowed_patterns() -> list[str]:
+            base_patterns = ["https://legacy-app.example.com/*"]
+            if feature_flags["enable_new_redirect_uris"]:
+                base_patterns.append("https://new-app.example.com/*")
+            return base_patterns
+
+        config = self._create_base_config(
+            allowed_redirect_patterns_func=get_allowed_patterns,
+        )
+
+        # Initial call - feature flag disabled
+        patterns = config.allowed_redirect_patterns_func()
+        assert patterns == ["https://legacy-app.example.com/*"]
+
+        # Enable feature flag
+        feature_flags["enable_new_redirect_uris"] = True
+
+        # Call again - should include new pattern
+        patterns = config.allowed_redirect_patterns_func()
+        assert patterns == ["https://legacy-app.example.com/*", "https://new-app.example.com/*"]
+
+    def test_callable_with_async_simulation(self) -> None:
+        """Test that callable can wrap async operations (sync wrapper pattern)."""
+        # Simulate a database lookup that might be async in real code
+        db_allowed_uris = ["https://db-uri-1.example.com/callback"]
+
+        def sync_db_lookup_wrapper(uri: str) -> bool:
+            # In real code, this might use asyncio.run() or similar
+            return uri in db_allowed_uris
+
+        config = self._create_base_config(
+            redirect_uri_validator=sync_db_lookup_wrapper,
+        )
+
+        assert config.redirect_uri_validator("https://db-uri-1.example.com/callback") is True
+        assert config.redirect_uri_validator("https://unknown.example.com/callback") is False
+
+        # Simulate adding a new URI to the "database"
+        db_allowed_uris.append("https://new-uri.example.com/callback")
+
+        # Validator should now accept the new URI
+        assert config.redirect_uri_validator("https://new-uri.example.com/callback") is True


### PR DESCRIPTION
## Description

This PR adds support for dynamic redirect URI validation in OAuth proxy configuration, enabling runtime evaluation of allowed redirect patterns and schemes. This allows integration with feature flags, databases, and other dynamic configuration sources.

Previously, redirect URI validation was limited to static lists defined at startup. The new feature introduces three new configuration options:
- `allowed_redirect_patterns_func`: A callable that returns redirect URI patterns dynamically
- `allowed_redirect_schemes_func`: A callable that returns allowed URI schemes dynamically  
- `redirect_uri_validator`: A custom validator function for complex validation logic

These work alongside existing static configuration options, providing flexibility for different use cases.

## Changes

### Core Changes
- **providers.py**: Added type aliases (`RedirectPatternsProvider`, `RedirectSchemesProvider`, `RedirectUriValidator`) and new fields to `OAuthProxyConfig` for dynamic redirect URI validation
- **__init__.py**: Exported new type aliases for public API
- **factory.py**: Updated `_create_oauth_proxy_provider` to resolve static patterns from environment variables and pass through callable functions to the enterprise package
- **__init__.py (configure_oauth_proxy)**: Added new parameters and comprehensive documentation with examples

### Testing
- **test_providers.py**: Added comprehensive test suite (`TestOAuthProxyDynamicRedirectUris`) covering:
  - Static redirect patterns and schemes configuration
  - Callable patterns and schemes functions
  - Custom redirect URI validators
  - Mixed static and dynamic configuration
  - Environment variable resolution
  - Feature flag integration patterns
  - Database lookup simulation

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Backward Compatibility

This change is fully backward compatible. Existing code using static `allowed_redirect_patterns` and `allowed_redirect_schemes` continues to work unchanged. The new callable-based parameters are optional and only used when explicitly provided.

## Use Cases

1. **Feature Flags**: Dynamically enable/disable redirect URIs based on feature flag state
2. **Database-Driven Configuration**: Fetch allowed URIs from a database at runtime
3. **Complex Validation**: Implement custom validation logic beyond pattern matching
4. **Multi-Tenant Systems**: Return different allowed URIs based on tenant context

https://claude.ai/code/session_01YLH7X7ZigGktYJQtthjQjq